### PR TITLE
Refactor: Apply suggestions from code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,33 @@ Key components:
 *   **`home-manager/`**: Shared Home Manager configurations applicable to both macOS and NixOS.
 *   **`taskfile.yml`**: A task runner file to simplify common operations like applying configurations.
 
+## Secrets Management
+
+This configuration uses [sops-nix](https://github.com/Mic92/sops-nix) for managing secrets like API keys and passwords declaratively and securely.
+
+**Prerequisites:**
+*   You need `sops` installed and configured on your system. Typically, this involves setting up a GPG key.
+    ```bash
+    # Example: Install sops (macOS with Homebrew)
+    brew install sops
+    # Example: Install sops (Nix)
+    # nix-env -iA nixpkgs.sops
+    ```
+*   Ensure your GPG key is available and configured for sops. You might need a `.sops.yaml` file in the repository root to specify default encryption rules (e.g., your GPG key fingerprint). Example `.sops.yaml`:
+    ```yaml
+    creation_rules:
+      - pgp: 'YOUR_GPG_FINGERPRINT_HERE'
+    ```
+
+**Working with Secrets:**
+1.  Secrets are defined in `secrets.yaml` at the root of the repository.
+2.  **Important:** This file should be encrypted using `sops`.
+    *   To edit secrets: `sops secrets.yaml`
+    *   After editing and saving, `sops` will automatically re-encrypt the file if your environment is set up correctly (e.g., GPG agent).
+    *   To encrypt an existing plaintext `secrets.yaml`: `sops --encrypt --in-place secrets.yaml`
+3.  The Nix configurations (`NixOS` and `Home Manager`) will automatically decrypt these secrets at build time when applying the configuration.
+4.  Refer to `secrets.yaml` for the structure of expected secrets (e.g., `restic_password`, `openrouter_api_key`).
+
 ## Using Tasks with `task`
 
 This repository uses [Task](https://taskfile.dev/) as a command runner, similar to `make` or `just`. It helps automate common development and system management workflows.

--- a/backup_pass.txt
+++ b/backup_pass.txt
@@ -1,1 +1,0 @@
-xfxiBHcqlghk1TDLMok0NPQC8CzI5DUL/Tdt3ajYESw=

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -1,6 +1,8 @@
 {
   self,
   pkgs,
+  username, # Injected from specialArgs
+  home-directory, # Injected from specialArgs
   ...
 }: {
   imports = [
@@ -233,7 +235,7 @@
     settings = {
       trusted-users = [
         "root"
-        "aloys"
+        username # Use abstracted username
       ];
     };
     extraOptions = ''
@@ -243,9 +245,9 @@
   };
 
   # Declare the user that will be running `nix-darwin`
-  users.users.aloys = {
-    name = "$USER";
-    home = "/Users/$USER";
+  users.users.${username} = { # Use abstracted username
+    name = username; # Use abstracted username
+    home = home-directory; # Use abstracted home-directory
   };
 
   security.pam.services.sudo_local.touchIdAuth = true;

--- a/dotfiles/hypr/hyprpaper.conf
+++ b/dotfiles/hypr/hyprpaper.conf
@@ -1,2 +1,2 @@
-preload = /home/aloys//.config/wallpapers/nord_wave.png
-wallpaper = , /home/aloys//.config/wallpapers/nord_wave.png
+preload = @HOME@/.config/wallpapers/nord_wave.png
+wallpaper = , @HOME@/.config/wallpapers/nord_wave.png

--- a/dotfiles/nvim/plugin/debug.lua
+++ b/dotfiles/nvim/plugin/debug.lua
@@ -29,7 +29,7 @@ require("lze").load {
           port = 2345,
           substitutePath = {
             {
-              from = "/Users/aloys/code/dabble/api.telescope.co/http-api/",
+              from = os.getenv("HOME") .. "/code/dabble/api.telescope.co/http-api/",
               to   = "/app", -- inside container
             },
           },

--- a/home-manager/scripts.nix
+++ b/home-manager/scripts.nix
@@ -1,12 +1,19 @@
-# Copy my scripts in a "script" dir
-# TODO: clean this up
-{config}: let
-  # Define the folders you want to symlink explicitly
-  pathToFolder = "${config.home.homeDirectory}/.config/nix/scripts";
-in {
-  ".config/scripts" = {
-    source = config.lib.file.mkOutOfStoreSymlink pathToFolder;
+# Symlinks the content of ./scripts from flake root to ~/.config/scripts
+{
+  config,
+  userScripts, # Injected from symlinks.nix (originally from flake.nix)
+  ...
+}:
+# let
+  # pathToFolder = "${config.home.homeDirectory}/.config/nix/scripts"; # Old way
+# in
+{
+  # This will create a symlink from ~/.config/scripts to the ./scripts directory in the Nix store.
+  # All files from ./scripts will then be available under ~/.config/scripts/
+  # For example, REPO_ROOT/scripts/backup -> /nix/store/...-scripts/backup -> ~/.config/scripts/backup
+  home.file.".config/scripts" = {
+    source = userScripts; # userScripts is the path to the ./scripts directory from flake root
     force = true;
-    recursive = true;
+    recursive = true; # Ensures the directory is linked
   };
 }

--- a/home-manager/symlinks.nix
+++ b/home-manager/symlinks.nix
@@ -6,6 +6,7 @@
   config,
   lib,
   pkgs,
+  dotfiles, # Injected from extraSpecialArgs
   ...
 }: let
   # Define the folders you want to symlink explicitly
@@ -21,19 +22,29 @@
     ++ lib.optionals pkgs.stdenv.isLinux [
       "waybar"
       "rofi"
-      "hypr"
+      # "hypr" # hypr configs are handled by home.file for hyprpaper.conf and wayland.windowManager.hyprland.extraConfig
       "wallpapers"
     ];
-  pathToFolder = "${config.home.homeDirectory}/.config/nix/dotfiles";
+  # pathToFolder is now the injected dotfiles path from the flake root
+  # pathToFolder = "${config.home.homeDirectory}/.config/nix/dotfiles"; # Old way
 in {
   home.file =
     lib.listToAttrs (lib.lists.forEach foldersToSymlink (folder: {
-      name = ".config/${folder}";
+      name = ".config/${folder}"; # Symlink target, e.g., ~/.config/nvim
       value = {
-        source = config.lib.file.mkOutOfStoreSymlink "${pathToFolder}/${folder}";
+        source = "${dotfiles}/${folder}"; # Symlink source, e.g., REPO_ROOT/dotfiles/nvim
+                                          # mkOutOfStoreSymlink is not needed if `dotfiles` is a store path.
+                                          # If `dotfiles` is just a path string like "./dotfiles",
+                                          # then mkOutOfStoreSymlink is appropriate if it needs to point
+                                          # outside the store. Given it's from flake root, it will be copied to store.
+                                          # So direct path should be fine.
         force = true;
-        recursive = true;
+        recursive = true; # recursive for symlinks typically means if source is a dir, target is a dir.
+                         # For home.file, `source` being a directory and `recursive = true` is not standard.
+                         # Usually, `home.file.<path>.source` points to a file.
+                         # To link directories, `home.xdg.configFile.<name>.source = path` is better.
+                         # Or just ensure the `source` is treated as a directory by `home.file`.
       };
     }))
-    // import ./scripts.nix {inherit config;};
+    // import ./scripts.nix {inherit config pkgs lib dotfiles userScripts;}; # Pass userScripts
 }

--- a/nix.conf
+++ b/nix.conf
@@ -1,2 +1,0 @@
-extra-experimental-features = nix-command flakes
-trusted-users = root aloys

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -1,0 +1,19 @@
+# This is a placeholder secrets file.
+# It should be encrypted with sops using a GPG key or other KMS.
+# Example structure:
+#
+# restic_password: "ENC[...]"
+# openrouter_api_key: "ENC[...]"
+#
+# To encrypt this file:
+# sops --encrypt --in-place secrets.yaml
+#
+# Ensure your .sops.yaml configuration specifies the correct key(s) for encryption.
+# For example, if using a GPG key:
+# creation_rules:
+#  - pgp: '<YOUR_GPG_FINGERPRINT>'
+
+# Placeholder values (these are NOT encrypted)
+# Replace with actual encrypted values using sops
+restic_password: "replace_with_encrypted_restic_password"
+openrouter_api_key: "replace_with_encrypted_openrouter_api_key"

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -25,10 +25,9 @@ tasks:
   nvim-reload:
     desc: "Reload nvim configuration by reinstalling the nix profile"
     cmds:
-      - nix profile remove dotfiles/nvim
-      - nix profile install git+file:///Users/aloys/.config/nix?dir=dotfiles/nvim#nvim
-      # Using the absolute path as it was in the justfile.
-      # Consider making this path relative or configurable if needed elsewhere.
+      # This assumes the task is run from the repo root.
+      - nix profile remove dotfiles/nvim # The profile name is 'dotfiles/nvim'
+      - nix profile install .?dir=dotfiles/nvim#nvim # Builds from ./dotfiles/nvim directory in the current repo
 
   default:
     desc: "Show available tasks"


### PR DESCRIPTION
This commit implements a series of improvements based on a code review, focusing on enhancing portability, security, and adherence to Nix best practices.

Key changes include:

High-Impact Improvements:
- Abstracted Usernames and Home Directories:
  - Defined `username` and `homeDirectory` centrally in `flake.nix`.
  - Passed these values via `specialArgs` to NixOS, Nix-Darwin, and Home Manager configurations.
  - Updated modules to use these injected values, removing hardcoded instances.
- Implemented Secrets Management with `sops-nix`:
  - Added `sops-nix` as a flake input.
  - Integrated `sops-nix` into NixOS and Home Manager configurations.
  - Migrated secrets (e.g., Restic password, OpenRouter API key) to be managed via an encrypted `secrets.yaml` file.
  - Removed `backup_pass.txt`.

Structural & Best Practice Improvements:
- Improved Symlink Pathing:
  - Passed dotfiles and scripts directories from `flake.nix` root to Home Manager.
  - Updated `symlinks.nix` and `scripts.nix` to use these paths, directly linking from the repository source (via Nix store).
- Centralized Overlays:
  - Consolidated all Nixpkgs overlays into `flake.nix`.
  - Ensured overlays are applied consistently to `pkgs` for all system configurations.
- Enhanced `taskfile.yml` Portability:
  - Updated `nvim-reload` task to use a repository-relative path for installing the Neovim configuration.

Minor Refinements & Cleanups:
- Removed unused `emacs-plus` Homebrew tap from flake inputs and configuration.
- Deleted redundant root `nix.conf` file, relying on declarative settings.
- Updated `README.md` to include instructions for `sops-nix` based secrets management.

These changes make the Nix configuration more robust, easier to maintain, and more secure by handling secrets properly.